### PR TITLE
Fix for 'Apps list overview get delete working'

### DIFF
--- a/routes/items.js
+++ b/routes/items.js
@@ -87,7 +87,7 @@ router.post(
 
     const item = await Item.create(req.body)
 
-    if (req.body.users === undefined) {
+    if (req.body.users === undefined || req.body.users === null) {
       req.body.users = [req.user.id]
     }
 


### PR DESCRIPTION
'req.body.users' is initialized as 'null' on the client, so is submitted as such to the server. Took this route as it seemed to be safest to other code.

Once 'users' is populated, the correct links between the 'admin' tile and the user record get created, then allowing deletes to happen