### PR TITLE
Add protocol and certificate options fix checking

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -174,12 +174,7 @@ router.get(
       let targetUrl = `${req.url.replace('/cors/', '')}`
       response = await axios({
         url: targetUrl,
-        method: 'GET',
-        httpsAgent: new https.Agent({
-          // Doing this allows us to accept self-signed certs.
-          // Debatable whether we want to do this or not. Option?
-          rejectUnauthorized: false
-        })
+        method: 'GET'
       })
       return res.send(response.data)
     } catch (e) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,6 +9,7 @@ const axios = require('axios')
 const fs = require('fs')
 const Docker = require('dockerode')
 const errorHandler = require('../middleware/error-handler')
+const https = require('https')
 
 /* GET home page. */
 router.get('/', (req, res, next) => {
@@ -168,10 +169,52 @@ router.get(
         result: null
       })
     }
+    let response
+    try {
+      let targetUrl = `${req.url.replace('/cors/', '')}`
+      response = await axios({
+        url: targetUrl,
+        method: 'GET',
+        httpsAgent: new https.Agent({
+          // Doing this allows us to accept self-signed certs.
+          // Debatable whether we want to do this or not. Option?
+          rejectUnauthorized: false
+        })
+      })
+      return res.send(response.data)
+    } catch (e) {
+      return res.json({
+        result: e
+      })
+    }
+  })
+)
 
-    const response = await axios.get(req.url.replace('/cors/', ''))
-
-    return res.send(response.data)
+router.post(
+  '/cors',
+  errorHandler(async (req, res, next) => {
+    if (!req.user) {
+      return res.status(401).json({
+        status: 'unauthorized',
+        result: null
+      })
+    }
+    let response
+    try {
+      const { allowSelfSignedCertificates, targetUrl } = req.body
+      response = await axios({
+        url: targetUrl,
+        method: 'GET',
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: allowSelfSignedCertificates === false
+        })
+      })
+      return res.send(response.data)
+    } catch (e) {
+      return res.json({
+        result: e
+      })
+    }
   })
 )
 

--- a/src/components/EditTile.vue
+++ b/src/components/EditTile.vue
@@ -37,9 +37,9 @@
 
             <q-tab-panels v-model="tab" animated class="">
               <q-tab-panel name="general">
+                <q-checkbox v-model="useritemactive" :label="this.$t('Active')" />
                 <q-input outlined v-model="title" :label="this.$t('title')" :rules="[val => !!val || this.$t('required_field')]"></q-input>
-
-                <q-select outlined label="Protocol" v-model="websiteprotocol" :options="['https', 'http']"></q-select>
+                <q-select outlined :label="this.$t('protocol')" v-model="websiteprotocol" :options="['https', 'http']"></q-select>
                 <q-input outlined v-model="url" :label="this.$t('url')" :rules="[val => !!val || this.$t('required_field')]"></q-input>
                 <q-checkbox v-model="allowselfsignedcerts" v-show="websiteprotocol === 'https'" :label="this.$t('Allow self-signed certificates')" />
                 <q-input v-model="description" :label="this.$t('description')" outlined type="textarea" />
@@ -253,6 +253,7 @@ export default {
       title: null,
       tags: null,
       users: null,
+      useritemactive: null,
       url: null,
       icon: null,
       newicon: null,
@@ -295,27 +296,29 @@ export default {
 
   watch: {
     application: function (newdata, olddata) {
+      console.log(newdata)
       this.id = newdata.id
       this.icon = newdata.icon
       this.title = newdata.title
       this.users = newdata.Users
+      this.useritemactive = (newdata.UserItem && Object.prototype.hasOwnProperty.call(newdata.UserItem, 'active') && newdata.UserItem.active) || false
       this.tags = newdata.tags
       this.description = newdata.description
       this.color = newdata.color
       this.url = newdata.url
       this.applicationtype = newdata.applicationType
-      this.enhancedType = newdata.config.enhancedType || false
-      this.websiteprotocol = newdata.config.websiteprotocol || 'https'
-      this.allowselfsignedcerts = newdata.config.allowselfsignedcerts || false
-      this.apikey = newdata.config.apikey || ''
-      this.enhanced1name = newdata.config.stat1.name || null
-      this.enhanced1url = newdata.config.stat1.url || null
-      this.enhanced1key = newdata.config.stat1.key || null
-      this.enhanced1filter = newdata.config.stat1.filter || null
-      this.enhanced2name = newdata.config.stat2.name || null
-      this.enhanced2url = newdata.config.stat2.url || null
-      this.enhanced2key = newdata.config.stat2.key || null
-      this.enhanced2filter = newdata.config.stat2.filter || null
+      this.enhancedType = (newdata.config && newdata.config.enhancedType) || false
+      this.websiteprotocol = (newdata.config && newdata.config.websiteprotocol) || 'https'
+      this.allowselfsignedcerts = (newdata.config && newdata.config.allowselfsignedcerts) || false
+      this.apikey = (newdata.config && newdata.config.apikey) || ''
+      this.enhanced1name = (newdata.config && newdata.config.stat1.name) || null
+      this.enhanced1url = (newdata.config && newdata.config.stat1.url) || null
+      this.enhanced1key = (newdata.config && newdata.config.stat1.key) || null
+      this.enhanced1filter = (newdata.config && newdata.config.stat1.filter) || null
+      this.enhanced2name = (newdata.config && newdata.config.stat2.name) || null
+      this.enhanced2url = (newdata.config && newdata.config.stat2.url) || null
+      this.enhanced2key = (newdata.config && newdata.config.stat2.key) || null
+      this.enhanced2filter = (newdata.config && newdata.config.stat2.filter) || null
     },
     create: function (newdata, olddata) {
       if (newdata === true) {
@@ -352,17 +355,12 @@ export default {
       if (this.url !== null) formData.url = this.url
       if (this.description !== null) formData.description = this.description
       formData.config = this.config
-      console.log({
-        config: this.config,
-        icon: this.icon
-      })
+
       if (this.icon !== null && this.icon !== undefined && this.icon !== this.application.icon) {
         if (this.icon.startsWith('http')) {
           formData.icon = this.icon
         }
       }
-      console.log('this.newicon')
-      console.log(this.newicon)
       if (this.$route.path === '/admin/application') {
         formData.system = true
         formData.users = this.users
@@ -381,6 +379,17 @@ export default {
             id: saveditem.data.result.id,
             media: media
           })
+        }
+
+        try {
+          await this.$store.dispatch('tiles/active', {
+            id: this.application.id,
+            data: {
+              active: this.useritemactive === true
+            }
+          })
+        } catch (e) {
+          console.error(e)
         }
 
         if (this.$route.path === '/admin/application') {
@@ -434,7 +443,6 @@ export default {
       this.title = this.applicationtype.name
       this.description = this.applicationtype.description
       this.icon = 'https://raw.githubusercontent.com/linuxserver/Heimdall-Apps/master/' + this.applicationtype.name + '/' + this.applicationtype.icon
-      // console.log(this.applicationtype.config)
       if (this.applicationtype.config !== null) {
         this.enhancedType = this.applicationtype.config.type
         this.enhanced1name = this.applicationtype.config.stat1.name

--- a/src/components/TileWebsiteTest.vue
+++ b/src/components/TileWebsiteTest.vue
@@ -1,0 +1,175 @@
+<template>
+  <q-card>
+    <q-card-section>
+      <div class="text-h6">Enter website address</div>
+    </q-card-section>
+    <q-card-section style="width: 500px" class="q-pt-none">
+      <q-select outlined label="Protocol" v-model="websiteprotocol" :options="['https', 'http']"></q-select>
+      <q-input outlined v-model="url" :label="this.$t('website')"></q-input>
+      <q-checkbox v-show="websiteprotocol === 'https'" v-model="allowSelfSignedCertificates" label="Allow self-signed and/or invalid certificates"></q-checkbox>
+      <q-btn flat label="Lookup" @click="getWebsiteData" :loading="websitetest === 'In Progress'" />
+      <div class="iconlist" v-if="websitedata">
+        <div class="icon" :class="{ selected: key === selectedwebsiteimage }" v-for="(icon, key) in websitedata.icons" :key="key" @click="selectWebsiteImage(key)">
+          <img :src="icon" />
+        </div>
+      </div>
+    </q-card-section>
+
+    <q-card-actions align="right">
+      <q-btn flat label="Cancel" color="primary" v-close-popup />
+      <q-btn unelevated v-if="websitedata !== null" label="Set" @click="setWebsite" color="primary" v-close-popup />
+    </q-card-actions>
+  </q-card>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'TileWebsiteTester',
+
+  props: {
+    website: {
+      type: String
+    },
+    protocol: {
+      type: String
+    },
+    allowselfsignedcerts: {
+      type: Boolean
+    }
+  },
+
+  components: {},
+
+  computed: {},
+
+  data() {
+    return {
+      websitetest: false,
+      websiteprotocol: this.protocol,
+      selectedwebsiteimage: null,
+      selected: null,
+      websitedata: null,
+      allowSelfSignedCertificates: this.allowselfsignedcerts,
+      url: this.website
+    }
+  },
+
+  methods: {
+    setWebsite() {
+      this.$emit('setWebsite', {
+        title: this.websitedata.title,
+        description: this.websitedata.description,
+        icon: this.websitedata.icons[this.selectedwebsiteimage],
+        url: this.url,
+        websiteprotocol: this.websiteprotocol,
+        allowSelfSignedCertificates: this.allowSelfSignedCertificates
+      })
+    },
+    selectWebsiteImage(key) {
+      this.selectedwebsiteimage = key
+    },
+    async getWebsiteData() {
+      this.websitetest = 'In Progress'
+      let html
+      try {
+        html = await axios.post(process.env.BACKEND_LOCATION + 'cors', {
+          url: `${this.websiteprotocol}://${this.url}`,
+          allowSelfSignedCertificates: this.allowSelfSignedCertificates
+        })
+      } catch (websiteLookupError) {
+        this.websitetest = 'Error'
+      }
+      this.websitetest = 'Success'
+      try {
+        const websitedata = {}
+        const parser = new DOMParser()
+        const document = parser.parseFromString(await html.data, 'text/html')
+
+        const links = document.getElementsByTagName('link')
+        websitedata.title = document.getElementsByTagName('title')[0].innerText
+        const metas = document.getElementsByTagName('meta')
+        const icons = []
+
+        for (let i = 0; i < metas.length; i++) {
+          if (metas[i].getAttribute('name') === 'description') {
+            websitedata.description = metas[i].getAttribute('content')
+          }
+        }
+
+        for (let i = 0; i < links.length; i++) {
+          const link = links[i]
+
+          // Technically it could be null / undefined if someone didn't set it!
+          // People do weird things when building pages!
+          const rel = link.getAttribute('rel')
+          if (rel) {
+            // I don't know why people don't use indexOf more often
+            // It is faster than regex for simple stuff like this
+            // Lowercase comparison for safety
+            if (rel.toLowerCase().indexOf('icon') > -1) {
+              const href = link.getAttribute('href')
+
+              // Make sure href is not null / undefined
+              if (href) {
+                // Relative
+                // Lowercase comparison in case some idiot decides to put the
+                // https or http in caps
+                // Also check for absolute url with no protocol
+                if (href.toLowerCase().indexOf('https:') === -1 && href.toLowerCase().indexOf('http:') === -1 && href.indexOf('//') !== 0) {
+                  // This is of course assuming the script is executing in the browser
+                  // Node.js is a different story! As I would be using cheerio.js for parsing the html instead of document.
+                  // Also you would use the response.headers object for Node.js below.
+                  console.log('link: ' + this.url)
+                  let finalBase = ''
+                  if (this.url.endsWith('/')) {
+                    const baseurl = this.url.split('/')
+                    baseurl.pop()
+                    finalBase = baseurl.join('/')
+                  } else {
+                    finalBase = this.url
+                  }
+
+                  let absoluteHref = finalBase
+
+                  // We already have a forward slash
+                  // On the front of the href
+                  if (href.indexOf('/') === 0) {
+                    absoluteHref += href
+                  } else {
+                    // We don't have a forward slash
+                    // It is really relative!
+                    const path = window.location.pathname.split('/')
+                    path.pop()
+                    const finalPath = path.join('/')
+
+                    absoluteHref += finalPath + '/' + href
+                  }
+
+                  icons.push(absoluteHref)
+                } else if (href.indexOf('//') === 0) {
+                  // Absolute url with no protocol
+                  const absoluteUrl = window.location.protocol + href
+
+                  icons.push(absoluteUrl)
+                } else {
+                  // Absolute
+                  icons.push(href)
+                }
+              }
+            }
+          }
+        }
+        websitedata.icons = icons
+        this.websitedata = websitedata
+        console.log(websitedata)
+      } catch (e) {
+        console.log(e)
+      }
+    }
+  }
+}
+</script>
+
+<style></style>

--- a/src/store/tiles/actions.js
+++ b/src/store/tiles/actions.js
@@ -33,10 +33,11 @@ export function getPossibleApps(context, force = false) {
 }
 
 export function save(context, data) {
-  if (data.tile.url !== undefined && !data.tile.url.includes('://')) {
+  // Removing as we're storing the protocol separately now
+  /* if (data.tile.url !== undefined && !data.tile.url.includes('://')) {
     const prefix = 'https://'
     data.tile.url = prefix.concat(data.tile.url)
-  }
+  } */
   if (data.id === null) {
     return axios.post(process.env.BACKEND_LOCATION + 'items', data.tile)
   } else {


### PR DESCRIPTION
Moved website testing into separate component
change ‘cors’ request to POST, so you can submit a URL and settings
Add ‘Website protocol’ property, commit to database
Add ’no certificates’ to be passed into the config, store this on the application options
Implement ability for the ‘no certificates’ to be passed into the config, store this on the application options
Allow users to choose HTTP or HTTPS upfront when targetting a website
Add active option into EditTile page, is saved on 'Save', rather than immediate
Add basic errors when request to target website fails