### PR TITLE
Implement enhanced basic auth strategy

### DIFF
--- a/enhanced.js
+++ b/enhanced.js
@@ -16,10 +16,26 @@ class EnhancedApps {
         } else {
           stat2 = stat1
         }
+        break
+      case 'basic_auth':
+        stat1 = await this.basicauth(this.data.stat1.url)
+        if (this.data.stat1.url !== this.data.stat2.url && this.data.stat2.url) {
+          stat2 = await this.basicauth(this.data.stat2.url)
+        } else {
+          stat2 = stat1
+        }
+        break
+      case 'none':
+        break
+      case 'cookie':
+        break
+      default:
+        console.error(`unrecognized enhanced type for ${JSON.stringify(this)}`)
     }
+
     return {
-      stat1: stat1.data,
-      stat2: stat2.data
+      stat1: stat1.data.result || stat1.data,
+      stat2: stat1.data.result || stat2.data
     }
   }
 
@@ -28,6 +44,21 @@ class EnhancedApps {
     url = url.replace(':apikey:', this.data.apikey)
     try {
       const response = await axios.get(url)
+      return response
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async basicauth(url) {
+    url = url.replace(':url:', this.data.url)
+    try {
+      const response = await axios.get(url, {
+        auth: {
+          username: this.data.basic_auth_user,
+          password: this.data.basic_auth_password
+        }
+      })
       return response
     } catch (e) {
       console.error(e)

--- a/src/components/EditTile.vue
+++ b/src/components/EditTile.vue
@@ -37,11 +37,11 @@
 
             <q-tab-panels v-model="tab" animated class="">
               <q-tab-panel name="general">
-                <q-checkbox v-model="useritemactive" :label="this.$t('Active')" />
+                <q-checkbox v-model="useritemactive" :label="this.$t('active')" />
                 <q-input outlined v-model="title" :label="this.$t('title')" :rules="[val => !!val || this.$t('required_field')]"></q-input>
                 <q-select outlined :label="this.$t('protocol')" v-model="websiteprotocol" :options="['https', 'http']"></q-select>
                 <q-input outlined v-model="url" :label="this.$t('url')" :rules="[val => !!val || this.$t('required_field')]"></q-input>
-                <q-checkbox v-model="allowselfsignedcerts" v-show="websiteprotocol === 'https'" :label="this.$t('Allow self-signed certificates')" />
+                <q-checkbox v-model="allowselfsignedcerts" v-show="websiteprotocol === 'https'" :label="this.$t('allow_self_signed_certificates')" />
                 <q-input v-model="description" :label="this.$t('description')" outlined type="textarea" />
                 <q-select :label="this.$t('Tags')" outlined v-model="tags" multiple :options="possibletags" use-input new-value-mode="add-unique" emit-value use-chips ref="tags" @new-value="updateInput" @filter="filterFn" />
               </q-tab-panel>
@@ -78,7 +78,11 @@
                     <q-tab-panel name="cookie">Cookie based</q-tab-panel>
                     <q-tab-panel name="basic_auth">
                       <q-input outlined v-model="basic_auth_user" :label="this.$t('enter_basic_auth_user')"></q-input>
-                      <q-input outlined v-model="basic_auth_password" :label="this.$t('enter_basic_auth_password')"></q-input>
+                      <q-input outlined v-model="basic_auth_password" :label="this.$t('enter_basic_auth_password')" :type="basic_auth_hide_password ? 'password' : 'text'">
+                        <template v-slot:append>
+                          <q-icon :name="basic_auth_hide_password ? 'visibility_off' : 'visibility'" class="cursor-pointer" @click="basic_auth_hide_password = !basic_auth_hide_password" />
+                        </template>
+                      </q-input>
                     </q-tab-panel>
                   </q-tab-panels>
                   <div class="stats">
@@ -284,6 +288,7 @@ export default {
       apikey: '',
       basic_auth_user: '',
       basic_auth_password: '',
+      basic_auth_hide_password: true,
       enhanced1name: null,
       enhanced1url: null,
       enhanced1key: null,

--- a/src/components/EditTile.vue
+++ b/src/components/EditTile.vue
@@ -76,6 +76,10 @@
                       <q-input outlined v-model="apikey" :label="this.$t('enter_apikey')"></q-input>
                     </q-tab-panel>
                     <q-tab-panel name="cookie">Cookie based</q-tab-panel>
+                    <q-tab-panel name="basic_auth">
+                      <q-input outlined v-model="basic_auth_user" :label="this.$t('enter_basic_auth_user')"></q-input>
+                      <q-input outlined v-model="basic_auth_password" :label="this.$t('enter_basic_auth_password')"></q-input>
+                    </q-tab-panel>
                   </q-tab-panels>
                   <div class="stats">
                     <div class="stat">
@@ -201,6 +205,8 @@ export default {
         enhancedType: this.enhancedType,
         url: this.url,
         apikey: this.apikey,
+        basic_auth_user: this.basic_auth_user,
+        basic_auth_password: this.basic_auth_password,
         allowselfsignedcerts: this.allowselfsignedcerts,
         websiteprotocol: this.websiteprotocol,
         stat1: {
@@ -276,6 +282,8 @@ export default {
       dockers: [],
       enhancedType: 'disabled',
       apikey: '',
+      basic_auth_user: '',
+      basic_auth_password: '',
       enhanced1name: null,
       enhanced1url: null,
       enhanced1key: null,
@@ -313,6 +321,8 @@ export default {
       this.websiteprotocol = (newdata.config && newdata.config.websiteprotocol) || 'https'
       this.allowselfsignedcerts = (newdata.config && newdata.config.allowselfsignedcerts) || false
       this.apikey = (newdata.config && newdata.config.apikey) || ''
+      this.basic_auth_user = (newdata.config && newdata.config.basic_auth_user) || ''
+      this.basic_auth_password = (newdata.config && newdata.config.basic_auth_password) || ''
       this.enhanced1name = (newdata.config && newdata.config.stat1.name) || null
       this.enhanced1url = (newdata.config && newdata.config.stat1.url) || null
       this.enhanced1key = (newdata.config && newdata.config.stat1.key) || null
@@ -350,6 +360,8 @@ export default {
       }
     },
     async onSubmit(evt) {
+      this.stat1value = null
+      this.stat2value = null
       const applicationType = this.applicationtype !== null ? this.applicationtype.appid : null
       const formData = {
         title: this.title
@@ -472,6 +484,8 @@ export default {
       this.allowSelfSignedCertificates = data.allowSelfSignedCertificates
     },
     async closeCreate() {
+      this.stat1value = null
+      this.stat2value = null
       await this.$emit('closecreate')
       setTimeout(() => {
         this.$store.dispatch('tiles/clear')

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -86,14 +86,10 @@ export default {
       }
     },
     stat1valueinit: function (newdata, olddata) {
-      if (!this.stat1value) {
-        this.stat1value = newdata
-      }
+      this.stat1value = newdata
     },
     stat2valueinit: function (newdata, olddata) {
-      if (!this.stat2value) {
-        this.stat2value = newdata
-      }
+      this.stat2value = newdata
     }
   },
 

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -114,5 +114,11 @@ export default {
   disable_mfa: 'Disable Multi Factor Authentication',
   required_field: 'Required Field',
   page_title: 'Page Title',
-  header_title: 'Header Title'
+  header_title: 'Header Title',
+  allow_self_signed_certificates: 'Allow self-signed certificates',
+  basic_auth: 'Basic auth',
+  count: 'Count',
+  protocol: 'Protocol',
+  enter_basic_auth_user: 'Enter your username',
+  enter_basic_auth_password: 'Enter your password'
 }

--- a/src/plugins/EnhancedApps.js
+++ b/src/plugins/EnhancedApps.js
@@ -26,7 +26,7 @@ export default class EnhancedApps {
     } catch (e) {
       Notify.create({
         type: 'negative',
-        message: i18n.t('api_test_failure') + ': ' + e.response.data,
+        message: i18n.t('api_test_failure') + ': ' + JSON.stringify(e.response.data),
         progress: true,
         position: 'bottom',
         timeout: 1500
@@ -51,6 +51,10 @@ export default class EnhancedApps {
       {
         id: 'cookie',
         value: 'cookie'
+      },
+      {
+        id: 'basic_auth',
+        value: 'basic_auth'
       }
     ]
   }


### PR DESCRIPTION
Adding basic auth strategy. Tested with NZBget and the results take the form:

`{
    version: String
    result: Object
}`

so, just for now, there's a hack to reassign the 'result' object to the parent object, allowing no modifications to the consuming code on the client.

Added I18n for missing messages in previous commits