### PR TITLE
Removing the 'protocol' box and adding logic to show fields based on string content instead

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -72,7 +72,7 @@ class User extends Model {
 
   toJSON() {
     const retval = this.get()
-    retval.hasPasssword = retval.password !== null
+    retval.hasPassword = retval.password !== null
     delete retval.password
 
     return retval

--- a/package-lock.json
+++ b/package-lock.json
@@ -5582,12 +5582,6 @@
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001129",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001129.tgz",
-          "integrity": "sha512-9945fTVKS810DZITpsAbuhQG7Lam0tEfVbZlsBaCFZaszepbryrArS05PWmJSBQ6mta+v9iz0pUIAbW1eBILIg==",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6559,9 +6553,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001048",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
-      "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==",
+      "version": "1.0.30001165",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+      "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
       "dev": true
     },
     "capture-exit": {
@@ -19833,12 +19827,6 @@
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001122",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001122.tgz",
-          "integrity": "sha512-pxjw28CThdrqfz06nJkpAc5SXM404TXB/h5f4UJX+rrXJKE/1bu/KAILc2AY+O6cQIFtRjV9qOR2vaEp9LDGUA==",
-          "dev": true
         },
         "chalk": {
           "version": "4.1.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -196,9 +196,9 @@ router.post(
     }
     let response
     try {
-      const { allowSelfSignedCertificates, targetUrl } = req.body
+      const { allowSelfSignedCertificates, url } = req.body
       response = await axios({
-        url: targetUrl,
+        url,
         method: 'GET',
         httpsAgent: new https.Agent({
           rejectUnauthorized: allowSelfSignedCertificates === false

--- a/src/components/EditTile.vue
+++ b/src/components/EditTile.vue
@@ -357,8 +357,8 @@ export default {
   methods: {
     isValidURL(url) {
       try {
-        new URL(url)
-        return true
+        const validUrl = new URL(url)
+        return validUrl !== null
       } catch (e) {
         return false
       }

--- a/src/components/EditTile.vue
+++ b/src/components/EditTile.vue
@@ -357,8 +357,7 @@ export default {
   methods: {
     isValidURL(url) {
       try {
-        const validUrl = new URL(url)
-        console.log(validUrl)
+        new URL(url)
         return true
       } catch (e) {
         return false

--- a/src/components/TileWebsiteTest.vue
+++ b/src/components/TileWebsiteTest.vue
@@ -4,9 +4,8 @@
       <div class="text-h6">Enter website address</div>
     </q-card-section>
     <q-card-section style="width: 500px" class="q-pt-none">
-      <q-select outlined label="Protocol" v-model="websiteprotocol" :options="['https', 'http']"></q-select>
-      <q-input outlined v-model="url" :label="this.$t('website')"></q-input>
-      <q-checkbox v-show="websiteprotocol === 'https'" v-model="allowSelfSignedCertificates" label="Allow self-signed and/or invalid certificates"></q-checkbox>
+      <q-input outlined v-model="url" :label="this.$t('website')" :rules="[val => !!val || this.$t('required_field'), val => isValidURL(val) || this.$t('invalid_input_url')]"></q-input>
+      <q-checkbox v-show="appurlishttps" v-model="allowSelfSignedCertificates" label="Allow self-signed and/or invalid certificates"></q-checkbox>
       <div class="iconlist" v-if="websitedata">
         <div class="icon" :class="{ selected: key === selectedwebsiteimage }" v-for="(icon, key) in websitedata.icons" :key="key" @click="selectWebsiteImage(key)">
           <img :src="icon" />
@@ -45,12 +44,22 @@ export default {
 
   components: {},
 
-  computed: {},
+  computed: {
+    appurlishttps() {
+      if (!this.url) return false
+
+      try {
+        const url = new URL(this.url)
+        return url.protocol === 'https:'
+      } catch (e) {
+        return false
+      }
+    }
+  },
 
   data() {
     return {
       websitetest: false,
-      websiteprotocol: this.protocol,
       selectedwebsiteimage: null,
       selected: null,
       websitedata: null,
@@ -61,13 +70,21 @@ export default {
   },
 
   methods: {
+    isValidURL(url) {
+      try {
+        const validUrl = new URL(url)
+        console.log(validUrl)
+        return true
+      } catch (e) {
+        return false
+      }
+    },
     setWebsite() {
       this.$emit('setWebsite', {
         title: this.websitedata.title,
         description: this.websitedata.description,
         icon: this.websitedata.icons[this.selectedwebsiteimage],
         url: this.url,
-        websiteprotocol: this.websiteprotocol,
         allowSelfSignedCertificates: this.allowSelfSignedCertificates
       })
     },
@@ -81,7 +98,7 @@ export default {
       let html
       try {
         html = await axios.post(process.env.BACKEND_LOCATION + 'cors', {
-          url: `${this.websiteprotocol}://${this.url}`,
+          url: `${this.url}`,
           allowSelfSignedCertificates: this.allowSelfSignedCertificates
         })
       } catch (websiteLookupError) {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -120,5 +120,6 @@ export default {
   count: 'Count',
   protocol: 'Protocol',
   enter_basic_auth_user: 'Enter your username',
-  enter_basic_auth_password: 'Enter your password'
+  enter_basic_auth_password: 'Enter your password',
+  invalid_input_url: 'Please provide a full URL including protocol, such as https://'
 }


### PR DESCRIPTION
1.) Removed the 'protocol' variable. Added logic to validate the 'url' field instead, so that it must be a valid URL object
2.) Squashed a bug where the user model 'toJSON' method was passing back 'hasPasssword' (bad spelling) value
3.) Squashed a bug where the users attached to a tile were incorrectly evaluated before submitting to the backend. The body content was the 'User' object rather than the user_id variables from the User