### PR TITLE
fix: root domain detection

### DIFF
--- a/enhanced.js
+++ b/enhanced.js
@@ -8,7 +8,7 @@ class EnhancedApps {
     this.config = {
       httpsAgent: this.agent
     }
-    if('additional_headers' in this.data && this.data.additional_headers !== '') {
+    if ('additional_headers' in this.data && this.data.additional_headers !== '') {
       this.config.headers = JSON.parse(this.data.additional_headers)
     }
   }
@@ -21,7 +21,7 @@ class EnhancedApps {
 
     let method_name = this.data.enhancedType
 
-    switch(method_name) {
+    switch (method_name) {
       case 'basic_auth':
         await this.basic_auth()
         break
@@ -34,7 +34,7 @@ class EnhancedApps {
       stat1 = await this.externalCall(url1)
       if (url1 === url2) stat2 = stat1
       else stat2 = await this.externalCall(url2)
-    } catch(e) {
+    } catch (e) {
       throw e
     }
 
@@ -61,7 +61,6 @@ class EnhancedApps {
 
     return url
   }
-
 
   async basic_auth(url) {
     this.config.auth = {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const passport = require('passport')
+const getRootDomain = require('../src/utils/Helpers')
 
 module.exports = {
   authorize: (req, res, next) => {
@@ -12,7 +13,7 @@ module.exports = {
       if (user && !req.originalUrl.match(/\/logout/)) {
         // Extend the tokens life while the user is browsing
         const token = user.generateJWT()
-        const domain = req.hostname === 'localhost' ? 'localhost' : `.${req.hostname.split('.').slice(-2).join('.')}` // Set cookie on top level domain for auth proxying
+        const domain = getRootDomain(req.protocol + '://' + req.hostname + req.originalUrl) // Set cookie on top level domain for auth proxying
         res.cookie('jwt', token, {
           domain: domain,
           maxAge: 3600000

--- a/routes/enhanced.js
+++ b/routes/enhanced.js
@@ -35,7 +35,6 @@ router.post(
         status: 'ok',
         result: response
       })
-  
     } catch (e) {
       console.error(e)
       return res.status(e.response.status).json({
@@ -43,9 +42,7 @@ router.post(
         result: e.response.data
       })
     }
-
-
   })
 )
-  
+
 module.exports = router

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const axios = require('axios')
 const fs = require('fs')
 const Docker = require('dockerode')
 const errorHandler = require('../middleware/error-handler')
+const getRootDomain = require('../src/utils/Helpers')
 const https = require('https')
 
 /* GET home page. */
@@ -87,7 +88,7 @@ router.post(
     }
 
     const token = user.generateJWT()
-    const domain = req.hostname === 'localhost' ? 'localhost' : `.${req.hostname.split('.').slice(-2).join('.')}` // Set cookie on top level domain for auth proxying
+    const domain = getRootDomain(req.protocol + '://' + req.hostname + req.originalUrl) // Set cookie on top level domain for auth proxying
     res.cookie('jwt', token, {
       domain: domain,
       maxAge: 3600000
@@ -108,7 +109,7 @@ router.post(
 router.get(
   '/logout',
   errorHandler(async (req, res, next) => {
-    const domain = req.hostname === 'localhost' ? 'localhost' : `.${req.hostname.split('.').slice(-2).join('.')}` // Set cookie on top level domain for auth proxying
+    const domain = getRootDomain(req.protocol + '://' + req.hostname + req.originalUrl) // Set cookie on top level domain for auth proxying
     res.clearCookie('jwt', {
       domain: domain // Set cookie on top level domain for auth proxying
     })

--- a/src/utils/Helpers.js
+++ b/src/utils/Helpers.js
@@ -1,0 +1,13 @@
+const net = require('net')
+
+module.exports = function getRootDomain(url) {
+  const domain = new URL(url).hostname
+
+  if (net.isIP(domain)) {
+    return domain
+  }
+
+  const elems = domain.split('.')
+  const iMax = elems.length - 1
+  return elems.splice(elems.length >= 3 && (elems[iMax] + elems[iMax - 1]).length <= 5 ? -3 : -2).join('.')
+}


### PR DESCRIPTION
The current solution does not support second-level domains or IP addresses, the jwt cookie cannot be set properly and a user will be unable to login.

This change allows user to publish Heimdall on IP addresses or second-level domains successfully.